### PR TITLE
Removed `ignoredChats` configuration for push notification plugin

### DIFF
--- a/CENChatEngine.podspec
+++ b/CENChatEngine.podspec
@@ -53,22 +53,22 @@ Pod::Spec.new do |spec|
 
     spec.subspec 'Plugin' do |plugin|
         plugin.subspec 'TypingIndicator' do |typingIndicator|
-            typingIndicator.dependency 'CENChatEngine/BuilderInterfaceOff'
+            typingIndicator.dependency 'CENChatEngine/Core'
             typingIndicator.source_files = 'Plugins/CENTypingIndicator/**/*'
         end
 
         plugin.subspec 'RandomUsername' do |randomUsername|
-            randomUsername.dependency 'CENChatEngine/BuilderInterfaceOff'
+            randomUsername.dependency 'CENChatEngine/Core'
             randomUsername.source_files = 'Plugins/CENRandomUsername/**/*'
         end
 
         plugin.subspec 'UnreadMessages' do |unreadMessages|
-            unreadMessages.dependency 'CENChatEngine/BuilderInterfaceOff'
+            unreadMessages.dependency 'CENChatEngine/Core'
             unreadMessages.source_files = 'Plugins/CENUnreadMessages/**/*'
         end
 
         plugin.subspec 'Markdown' do |markdown|
-            markdown.dependency 'CENChatEngine/BuilderInterfaceOff'
+            markdown.dependency 'CENChatEngine/Core'
             markdown.source_files = 'Plugins/CENMarkdown/**/*'
             markdown.private_header_files = [
                 'Plugins/CENMarkdown/CENMarkdownParser+Private.h'
@@ -76,17 +76,17 @@ Pod::Spec.new do |spec|
         end
 
         plugin.subspec 'Gravatar' do |gravatar|
-            gravatar.dependency 'CENChatEngine/BuilderInterfaceOff'
+            gravatar.dependency 'CENChatEngine/Core'
             gravatar.source_files = 'Plugins/CENGravatar/**/*'
         end
 
         plugin.subspec 'OnlineUserSearch' do |onlineUserSearch|
-            onlineUserSearch.dependency 'CENChatEngine/BuilderInterfaceOff'
+            onlineUserSearch.dependency 'CENChatEngine/Core'
             onlineUserSearch.source_files = 'Plugins/CENOnlineUserSearch/**/*'
         end
 
         plugin.subspec 'PushNotifications' do |pushNotifications|
-            pushNotifications.dependency 'CENChatEngine/BuilderInterfaceOff'
+            pushNotifications.dependency 'CENChatEngine/Core'
             pushNotifications.source_files = 'Plugins/CENPushNotifications/**/*'
         end
 

--- a/Plugins/CENPushNotifications/CENPushNotificationsPlugin.h
+++ b/Plugins/CENPushNotifications/CENPushNotificationsPlugin.h
@@ -28,11 +28,6 @@ typedef struct CENPushNotificationsConfigurationKeys {
     __unsafe_unretained NSString *services;
     
     /**
-     * @brief  Stores reference on name of key under which stored list of chat names for which plugin shouldn't be used.
-     */
-    __unsafe_unretained NSString *ignoredChats;
-    
-    /**
      * @brief      Stores reference on name of key under which stored GCD block which should be used to provide custom payload format.
      * @discussion In case if \c services specified, plugin should be able to generate minimum push notification for each of specified services.
      *             If custom payload required, formatter can be used to override notification payload.

--- a/Plugins/CENPushNotifications/CENPushNotificationsPlugin.m
+++ b/Plugins/CENPushNotifications/CENPushNotificationsPlugin.m
@@ -17,9 +17,7 @@
 
 NSString * const kCENNotificationsErrorChatsKey = @"CENNotificationsErrorChatsKey";
 
-CENPushNotificationsConfigurationKeys CENPushNotificationsConfiguration = { .events = @"e", .services = @"s", .ignoredChats = @"i",
-                                                                            .formatter = @"f" };
-
+CENPushNotificationsConfigurationKeys CENPushNotificationsConfiguration = { .events = @"e", .services = @"s", .formatter = @"f" };
 CENPushNotificationsServices CENPushNotificationsService = { .apns = @"apns", .fcm = @"gcm" };
 
 
@@ -159,18 +157,12 @@ NS_ASSUME_NONNULL_END
 - (void)onCreate {
     
     NSMutableDictionary *configuration = [NSMutableDictionary dictionaryWithDictionary:self.configuration];
-    NSMutableArray<NSString *> *ignoredChats = [NSMutableArray arrayWithArray:configuration[CENPushNotificationsConfiguration.ignoredChats]];
     NSMutableArray<NSString *> *events = [NSMutableArray arrayWithArray:configuration[CENPushNotificationsConfiguration.events]];
     
     if (![events containsObject:@"$notifications.seen"]) {
         [events addObject:@"$notifications.seen"];
     }
     
-    if (![ignoredChats containsObject:@"feed"]) {
-        [ignoredChats addObject:@"feed"];
-    }
-    
-    configuration[CENPushNotificationsConfiguration.ignoredChats] = ignoredChats;
     configuration[CENPushNotificationsConfiguration.events] = events;
     
     self.configuration = configuration;

--- a/Tests/ChatEngine Tests.xcodeproj/project.pbxproj
+++ b/Tests/ChatEngine Tests.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		791553CE20B5945000BE7A83 /* CENChatEngineRemoteChatsListIntegrationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 791553CC20B5944F00BE7A83 /* CENChatEngineRemoteChatsListIntegrationTest.m */; };
 		791553D320B6CF6500BE7A83 /* CENChatEngineUserStateIntegrationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 791553D220B6CF6500BE7A83 /* CENChatEngineUserStateIntegrationTest.m */; };
 		791553D420B6CF6500BE7A83 /* CENChatEngineUserStateIntegrationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 791553D220B6CF6500BE7A83 /* CENChatEngineUserStateIntegrationTest.m */; };
+		7931F1F620DD20FC00D8CC83 /* CENPushNotificationsPluginIntegrationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7957E32720CC0BE9005E76EE /* CENPushNotificationsPluginIntegrationTest.m */; };
 		7945D5C620712B1F00FECBFB /* CEDummyEmitMiddleware.m in Sources */ = {isa = PBXBuildFile; fileRef = 797ED06320596848007E15F5 /* CEDummyEmitMiddleware.m */; };
 		7945D5C720712B1F00FECBFB /* CEDummyOnMiddleware.m in Sources */ = {isa = PBXBuildFile; fileRef = 797ED06220596848007E15F5 /* CEDummyOnMiddleware.m */; };
 		7945D5C820712B1F00FECBFB /* CEDummyExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = 797ED05820595E50007E15F5 /* CEDummyExtension.m */; };
@@ -1178,6 +1179,7 @@
 				79D63E5920C69CEB008ECBC7 /* CENRandomUsernamePluginIntegrationTest.m in Sources */,
 				791553C220B5895900BE7A83 /* CENChatBuilderInterfaceTest.m in Sources */,
 				79B10EC620808B17003EAFAD /* CENObjectPluginsTest.m in Sources */,
+				7931F1F620DD20FC00D8CC83 /* CENPushNotificationsPluginIntegrationTest.m in Sources */,
 				797F1BFE20BD920B00A37387 /* CENTypingIndicatorPluginIntegrationTest.m in Sources */,
 				79B10ECE20808B5F003EAFAD /* CENMeTest.m in Sources */,
 				79B10ECA20808B27003EAFAD /* CENObjectTest.m in Sources */,

--- a/Tests/Tests/Unit/Plugins/CENPushNotifications/CENPushNotificationsPluginTest.m
+++ b/Tests/Tests/Unit/Plugins/CENPushNotifications/CENPushNotificationsPluginTest.m
@@ -103,27 +103,6 @@
     XCTAssertTrue([events containsObject:@"$notifications.seen"]);
 }
 
-- (void)testConfiguration_ShouldAddIgnoredChat_WhenNilConfigurationPassed {
-    
-    NSArray<NSString *> *ignoredChats = self.defaultPlugin.configuration[CENPushNotificationsConfiguration.ignoredChats];
-    
-    XCTAssertNotNil(ignoredChats);
-    XCTAssertTrue([ignoredChats containsObject:@"feed"]);
-}
-
-- (void)testConfiguration_ShouldAddIgnoredChat_WhenConfigurationWithEventsPassed {
-    
-    NSDictionary *configuration = @{ CENPushNotificationsConfiguration.ignoredChats: @[@"private-chat"] };
-    CENPushNotificationsPlugin *plugin = [CENPushNotificationsPlugin pluginWithIdentifier:@"test" configuration:configuration];
-    
-    NSArray<NSString *> *ignoredChats = plugin.configuration[CENPushNotificationsConfiguration.ignoredChats];
-    
-    XCTAssertNotNil(ignoredChats);
-    XCTAssertEqual(ignoredChats.count, 2);
-    XCTAssertTrue([ignoredChats containsObject:@"private-chat"]);
-    XCTAssertTrue([ignoredChats containsObject:@"feed"]);
-}
-
 
 #pragma mark - Tests :: Extension
 


### PR DESCRIPTION
Changes:
* removed `ignoredChats` configuration for push notification plugin (list of affected chats managed by user).
* fixed warnings with macro re-definition because of dependency used in Podspec for plugins.
* returned integration test back to full coverage tests.