### PR TITLE
Replacing publish and subscribe key

### DIFF
--- a/docs/api-reference/chatengine/README.md
+++ b/docs/api-reference/chatengine/README.md
@@ -92,8 +92,8 @@ Configured and ready to use [CENChatEngine](../chatengine) client.
 ### Example
 
 ```objc
-CENConfiguration *configuration = [CENConfiguration configurationWithPublishKey:@"demo-36"
-                                                                   subscribeKey:@"demo-36"];
+CENConfiguration *configuration = [CENConfiguration configurationWithPublishKey:@"demo"
+                                                                   subscribeKey:@"demo"];
 self.client = [CENChatEngine clientWithConfiguration:configuration];
 ```
 

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -11,7 +11,7 @@ You can turn on debug mode by setting [CENConfiguration.debugevents](../api-refe
 ### Example
 
 ```objc
-CENConfiguration *configuration = [CENConfiguration configurationWithPublishKey:@"demo-36" subscribeKey:@"demo-36"];
+CENConfiguration *configuration = [CENConfiguration configurationWithPublishKey:@"demo" subscribeKey:@"demo"];
 configuration.debugevents = YES;
 self.client = [CENChatEngine clientWithConfiguration:configuration];
 ```


### PR DESCRIPTION
Replacing `demo-36` with `demo` in publish and subscribe key 